### PR TITLE
ci: 创建 nojekyll 文件在 GitHub Pages 部署过程中添加步骤，创建 .nojekyll 文件。这样可以防止 Git…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,10 @@ jobs:
           pnpm i --frozen-lockfile
           pnpm run build
 
+      - name: create nojekyll
+        run: echo > dist/.nojekyll
+
+
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4
         with:


### PR DESCRIPTION
…Hub 自动将 dist 目录下的 Jekyll 特定文件进行处理，确保网站正常运行。